### PR TITLE
feat: support for multi-line description and default

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -14,6 +14,7 @@ func TestActionParse(t *testing.T) {
 		{"complex parameter", complexActionFixture, complexActionExpected},
 		{"full parameter", fullActionFixture, fullActionExpected},
 		{"empty parameter", emptyActionFixture, emptyActionExpected},
+		{"complex multiline parameter", complexMultiLineActionFixture, complexMultiLineActionExpected},
 		{"invalid YAML", invalidActionFixture, invalidActionExpected},
 	}
 
@@ -112,7 +113,7 @@ This is a test Custom Action for actdocs.
 
 const emptyActionFixture = `
 name:
-description: 
+description:
 
 inputs:
   empty:
@@ -137,6 +138,49 @@ N/A
 | Name | Description |
 | :--- | :---------- |
 | only-value |  |
+`
+
+const complexMultiLineActionFixture = `
+name: Test Fixture
+description: This is a test Custom Action for actdocs.
+
+inputs:
+  multiline-string:
+    default: |
+      {
+        "key": "value"
+      }
+    required: true
+    description: |
+      The multiline string.
+      Like this.
+  empty:
+
+outputs:
+  with-multiline-description:
+    description: |
+      The Render value with multiline description.
+      Like this.
+    value: ${{ inputs.description-only }}
+`
+
+const complexMultiLineActionExpected = `
+## Description
+
+This is a test Custom Action for actdocs.
+
+## Inputs
+
+| Name | Description | Default | Required |
+| :--- | :---------- | :------ | :------: |
+| multiline-string | <pre>The multiline string.<br>Like this.</pre> | <pre>{<br>  "key": "value"<br>}</pre> | yes |
+| empty |  | n/a | no |
+
+## Outputs
+
+| Name | Description |
+| :--- | :---------- |
+| with-multiline-description | <pre>The Render value with multiline description.<br>Like this.</pre> |
 `
 
 const invalidActionFixture = `

--- a/type.go
+++ b/type.go
@@ -2,6 +2,8 @@ package actdocs
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 )
 
 const TableSeparator = "|"
@@ -34,6 +36,9 @@ func (s *NullString) MarshalJSON() ([]byte, error) {
 
 func (s *NullString) StringOrEmpty() string {
 	if s.valid {
+		if strings.Contains(s.value, "\n") {
+			return s.sanitizeString()
+		}
 		return s.value
 	}
 	return emptyString
@@ -65,7 +70,18 @@ func (s *NullString) IsTrue() bool {
 }
 
 func (s *NullString) quoteString() string {
+	if strings.Contains(s.value, "\n") {
+		return s.sanitizeString()
+	}
 	return "`" + s.value + "`"
+}
+
+func (s *NullString) sanitizeString() string {
+	var str string
+	str = strings.TrimSuffix(s.value, "\n")
+	str = strings.ReplaceAll(str, "\n", lineBreak)
+	str = strings.ReplaceAll(str, "\r", "")
+	return fmt.Sprintf("%s%s%s", codeStart, str, codeEnd)
 }
 
 const emptyString = ""
@@ -74,3 +90,7 @@ const noString = "no"
 
 const LowerNAString = "n/a"
 const UpperNAString = "N/A"
+
+const codeStart = "<pre>"
+const codeEnd = "</pre>"
+const lineBreak = "<br>"

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -14,6 +14,7 @@ func TestWorkflowParse(t *testing.T) {
 		{"complex parameter", complexWorkflowFixture, complexWorkflowExpected},
 		{"full parameter", fullWorkflowFixture, fullWorkflowExpected},
 		{"empty parameter", emptyWorkflowFixture, emptyWorkflowExpected},
+		{"multiline parameter", multiLineWorkflowFixture, multiLineWorkflowExpected},
 		{"invalid YAML", invalidWorkflowFixture, invalidWorkflowExpected},
 	}
 
@@ -92,6 +93,28 @@ const emptyWorkflowExpected = `
 | Name | Description | Type | Default | Required |
 | :--- | :---------- | :--- | :------ | :------: |
 | empty |  | n/a | n/a | no |
+`
+
+const multiLineWorkflowFixture = `
+on:
+  workflow_call:
+    inputs:
+      multiline-string:
+        default: |
+          {
+            "key": "value"
+          }
+        required: false
+        type: string
+        description: |
+          The Multiline string.
+          Like this.
+`
+
+const multiLineWorkflowExpected = `
+| Name | Description | Type | Default | Required |
+| :--- | :---------- | :--- | :------ | :------: |
+| multiline-string | <pre>The Multiline string.<br>Like this.</pre> | ` + "`string`" + ` | <pre>{<br>  "key": "value"<br>}</pre> | no |
 `
 
 const invalidWorkflowFixture = `


### PR DESCRIPTION
## description
If provided an actions.yaml or workflow file with multiple lines of description or defaults, the Markdown table notation will be broken.

example.yaml
```yaml
name: example
on:
  workflow_call:
    inputs:
      example:
        description: |
          Example input
          Example input
        required: true
        default: |
          {
            "example": "example"
          }
```

outputs
```console
❯ actdocs generate example.yaml
## Inputs

| Name | Description | Type | Default | Required |
| :--- | :---------- | :--- | :------ | :------: |
| example | Example input
Example input
 | n/a | `{
  "example": "example"
}
` | yes |

## Secrets

N/A

## Outputs

N/A

## Permissions

N/A
```

So, implement sanitization as was done in terraform-docs to support output of multi-line markdown tables.

https://github.com/terraform-docs/terraform-docs/blob/577d2c88101b06207e6cf99845f259b9f2ed62c2/template/sanitizer.go#L116-L141

## environment
```
❯ uname -mo; actdocs --version
arm64 Darwin
actdocs version 0.4.0 (2022-11-08T04:34:40Z)%
```