### PR TITLE
Fix: Improve accuracy of Re-usable workflow detection using regex

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -1,11 +1,11 @@
 package actdocs
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"regexp"
 )
 
 type YamlFile string
@@ -62,11 +62,13 @@ func (y RawYaml) createYamlParser(globalConfig *GlobalConfig) (YamlParser, error
 }
 
 func (y RawYaml) isReusableWorkflow() bool {
-	return bytes.Contains(y, []byte("workflow_call:"))
+	r := regexp.MustCompile(`(?m)^[\s]*workflow_call:`)
+	return r.Match(y)
 }
 
 func (y RawYaml) isCustomActions() bool {
-	return bytes.Contains(y, []byte("runs:"))
+	r := regexp.MustCompile(`(?m)^[\s]*runs:`)
+	return r.Match(y)
 }
 
 type YamlParser interface {


### PR DESCRIPTION
Previously, the mere presence of `workflow_call:` within comments could lead to incorrect detections.
To mitigate this, I've enhanced the detection mechanism by utilizing the regex pattern `(?m)^[\s]*workflow_call:`.

I think that parsing the YAML to check for `on.workflow_call` would be the ideal approach.
However, I'm not deeply acquainted with Go and wasn't sure how to implement it. Thus, I opted for a simpler solution.
