### PR TITLE
feat: standardize JSON output field names by introducing lowercase struct tags

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -370,44 +370,44 @@ const expectedGenerateWithSortFormatJsonAction = `{
   "description": "This is a test Custom Action for actdocs.",
   "inputs": [
     {
-      "Name": "full-string",
-      "Default": "Default value",
-      "Description": "The full string value.",
-      "Required": "true"
+      "name": "full-string",
+      "default": "Default value",
+      "description": "The full string value.",
+      "required": "true"
     },
     {
-      "Name": "description-only",
-      "Default": null,
-      "Description": "The description without default and required.",
-      "Required": null
+      "name": "description-only",
+      "default": null,
+      "description": "The description without default and required.",
+      "required": null
     },
     {
-      "Name": "empty",
-      "Default": null,
-      "Description": null,
-      "Required": null
+      "name": "empty",
+      "default": null,
+      "description": null,
+      "required": null
     },
     {
-      "Name": "full-boolean",
-      "Default": "true",
-      "Description": "The full boolean value.",
-      "Required": "false"
+      "name": "full-boolean",
+      "default": "true",
+      "description": "The full boolean value.",
+      "required": "false"
     },
     {
-      "Name": "full-number",
-      "Default": "5",
-      "Description": "The full number value.",
-      "Required": "false"
+      "name": "full-number",
+      "default": "5",
+      "description": "The full number value.",
+      "required": "false"
     }
   ],
   "outputs": [
     {
-      "Name": "only-value",
-      "Description": null
+      "name": "only-value",
+      "description": null
     },
     {
-      "Name": "with-description",
-      "Description": "The output value with description."
+      "name": "with-description",
+      "description": "The output value with description."
     }
   ]
 }

--- a/internal/format/action.go
+++ b/internal/format/action.go
@@ -178,15 +178,15 @@ type ActionJson struct {
 }
 
 type ActionInputJson struct {
-	Name        string
-	Default     *util.NullString
-	Description *util.NullString
-	Required    *util.NullString
+	Name        string           `json:"name"`
+	Default     *util.NullString `json:"default"`
+	Description *util.NullString `json:"description"`
+	Required    *util.NullString `json:"required"`
 }
 
 type ActionOutputJson struct {
-	Name        string
-	Description *util.NullString
+	Name        string           `json:"name"`
+	Description *util.NullString `json:"description"`
 }
 
 type ActionMarkdown struct {

--- a/internal/format/action_test.go
+++ b/internal/format/action_test.go
@@ -111,26 +111,26 @@ const fullActionExpectedJson = `{
   "description": "This is a test Custom Action for actdocs.",
   "inputs": [
     {
-      "Name": "minimal",
-      "Default": null,
-      "Description": null,
-      "Required": null
+      "name": "minimal",
+      "default": null,
+      "description": null,
+      "required": null
     },
     {
-      "Name": "full",
-      "Default": "The string",
-      "Description": "The input value.",
-      "Required": "true"
+      "name": "full",
+      "default": "The string",
+      "description": "The input value.",
+      "required": "true"
     }
   ],
   "outputs": [
     {
-      "Name": "minimal",
-      "Description": null
+      "name": "minimal",
+      "description": null
     },
     {
-      "Name": "full",
-      "Description": "The output value."
+      "name": "full",
+      "description": "The output value."
     }
   ]
 }`


### PR DESCRIPTION
- updates JSON tags in ActionInputJson and ActionOutputJson structs
- aligns output format with typical JSON conventions (e.g., "name" instead of "Name")
- this is a breaking change for consumers relying on the old format
