### PR TITLE
refactor: move action formatting logic to internal/action package

### DIFF
--- a/internal/action/convert.go
+++ b/internal/action/convert.go
@@ -1,11 +1,11 @@
-package format
+package action
 
 import "github.com/tmknom/actdocs/internal/parse"
 
-func ConvertActionSpec(ast *parse.ActionAST) *ActionSpec {
-	inputs := []*ActionInputSpec{}
+func ConvertActionSpec(ast *parse.ActionAST) *Spec {
+	inputs := []*InputSpec{}
 	for _, inputAst := range ast.Inputs {
-		input := &ActionInputSpec{
+		input := &InputSpec{
 			Name:        inputAst.Name,
 			Default:     inputAst.Default,
 			Description: inputAst.Description,
@@ -14,16 +14,16 @@ func ConvertActionSpec(ast *parse.ActionAST) *ActionSpec {
 		inputs = append(inputs, input)
 	}
 
-	outputs := []*ActionOutputSpec{}
+	outputs := []*OutputSpec{}
 	for _, outputAst := range ast.Outputs {
-		output := &ActionOutputSpec{
+		output := &OutputSpec{
 			Name:        outputAst.Name,
 			Description: outputAst.Description,
 		}
 		outputs = append(outputs, output)
 	}
 
-	return &ActionSpec{
+	return &Spec{
 		Description: ast.Description,
 		Inputs:      inputs,
 		Outputs:     outputs,

--- a/internal/action/formatter.go
+++ b/internal/action/formatter.go
@@ -1,4 +1,4 @@
-package format
+package action
 
 import (
 	"encoding/json"
@@ -8,27 +8,27 @@ import (
 	"github.com/tmknom/actdocs/internal/parse"
 )
 
-type ActionFormatter struct {
+type Formatter struct {
 	config *conf.FormatterConfig
-	*ActionSpec
+	*Spec
 }
 
-func NewActionFormatter(config *conf.FormatterConfig) *ActionFormatter {
-	return &ActionFormatter{
+func NewActionFormatter(config *conf.FormatterConfig) *Formatter {
+	return &Formatter{
 		config: config,
 	}
 }
 
-func (f *ActionFormatter) Format(ast *parse.ActionAST) string {
-	f.ActionSpec = ConvertActionSpec(ast)
+func (f *Formatter) Format(ast *parse.ActionAST) string {
+	f.Spec = ConvertActionSpec(ast)
 
 	if f.config.IsJson() {
-		return f.ToJson(f.ActionSpec)
+		return f.ToJson(f.Spec)
 	}
-	return f.ToMarkdown(f.ActionSpec, f.config)
+	return f.ToMarkdown(f.Spec, f.config)
 }
 
-func (f *ActionFormatter) ToJson(actionSpec *ActionSpec) string {
+func (f *Formatter) ToJson(actionSpec *Spec) string {
 	bytes, err := json.MarshalIndent(actionSpec, "", "  ")
 	if err != nil {
 		return "{}"
@@ -36,7 +36,7 @@ func (f *ActionFormatter) ToJson(actionSpec *ActionSpec) string {
 	return string(bytes)
 }
 
-func (f *ActionFormatter) ToMarkdown(actionSpec *ActionSpec, config *conf.FormatterConfig) string {
+func (f *Formatter) ToMarkdown(actionSpec *Spec, config *conf.FormatterConfig) string {
 	var sb strings.Builder
 	if actionSpec.Description.IsValid() || !config.Omit {
 		sb.WriteString(actionSpec.toDescriptionMarkdown())

--- a/internal/action/formatter_test.go
+++ b/internal/action/formatter_test.go
@@ -1,4 +1,4 @@
-package format
+package action
 
 import (
 	"testing"
@@ -62,27 +62,27 @@ This is a test Custom Action for actdocs.
 func TestActionFormatter_ToJson(t *testing.T) {
 	cases := []struct {
 		name     string
-		json     *ActionSpec
+		json     *Spec
 		expected string
 	}{
 		{
 			name: "empty",
-			json: &ActionSpec{
+			json: &Spec{
 				Description: NewNullValue(),
-				Inputs:      []*ActionInputSpec{},
-				Outputs:     []*ActionOutputSpec{},
+				Inputs:      []*InputSpec{},
+				Outputs:     []*OutputSpec{},
 			},
 			expected: emptyActionExpectedJson,
 		},
 		{
 			name: "full",
-			json: &ActionSpec{
+			json: &Spec{
 				Description: NewNotNullValue("This is a test Custom Action for actdocs."),
-				Inputs: []*ActionInputSpec{
+				Inputs: []*InputSpec{
 					{Name: "minimal", Default: NewNullValue(), Description: NewNullValue(), Required: NewNullValue()},
 					{Name: "full", Default: NewNotNullValue("The string"), Description: NewNotNullValue("The input value."), Required: NewNotNullValue("true")},
 				},
-				Outputs: []*ActionOutputSpec{
+				Outputs: []*OutputSpec{
 					{Name: "minimal", Description: NewNullValue()},
 					{Name: "full", Description: NewNotNullValue("The output value.")},
 				},
@@ -138,38 +138,38 @@ func TestActionFormatter_ToMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
 		config   *conf.FormatterConfig
-		markdown *ActionSpec
+		markdown *Spec
 		expected string
 	}{
 		{
 			name:   "omit",
 			config: &conf.FormatterConfig{Format: conf.DefaultFormat, Omit: true},
-			markdown: &ActionSpec{
+			markdown: &Spec{
 				Description: NewNullValue(),
-				Inputs:      []*ActionInputSpec{},
-				Outputs:     []*ActionOutputSpec{},
+				Inputs:      []*InputSpec{},
+				Outputs:     []*OutputSpec{},
 			},
 			expected: "",
 		},
 		{
 			name:   "empty",
 			config: conf.DefaultFormatterConfig(),
-			markdown: &ActionSpec{
+			markdown: &Spec{
 				Description: NewNullValue(),
-				Inputs:      []*ActionInputSpec{},
-				Outputs:     []*ActionOutputSpec{},
+				Inputs:      []*InputSpec{},
+				Outputs:     []*OutputSpec{},
 			},
 			expected: emptyActionExpected,
 		},
 		{
 			name:   "full",
 			config: conf.DefaultFormatterConfig(),
-			markdown: &ActionSpec{
+			markdown: &Spec{
 				Description: NewNotNullValue("This is a test Custom Action for actdocs."),
-				Inputs: []*ActionInputSpec{
+				Inputs: []*InputSpec{
 					{Name: "full-number", Default: NewNotNullValue("5"), Description: NewNotNullValue("The full number value."), Required: NewNotNullValue("false")},
 				},
-				Outputs: []*ActionOutputSpec{
+				Outputs: []*OutputSpec{
 					{Name: "with-description", Description: NewNotNullValue("The Render value with description.")},
 				},
 			},
@@ -179,7 +179,7 @@ func TestActionFormatter_ToMarkdown(t *testing.T) {
 
 	for _, tc := range cases {
 		formatter := NewActionFormatter(tc.config)
-		formatter.ActionSpec = tc.markdown
+		formatter.Spec = tc.markdown
 		got := formatter.ToMarkdown(tc.markdown, tc.config)
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
 			t.Errorf("diff: %s", diff)

--- a/internal/action/helpers_test.go
+++ b/internal/action/helpers_test.go
@@ -1,0 +1,11 @@
+package action
+
+import "github.com/tmknom/actdocs/internal/util"
+
+func NewNullValue() *util.NullString {
+	return util.NewNullString(nil)
+}
+
+func NewNotNullValue(value string) *util.NullString {
+	return util.NewNullString(&value)
+}

--- a/internal/action/spec.go
+++ b/internal/action/spec.go
@@ -1,4 +1,4 @@
-package format
+package action
 
 import (
 	"fmt"
@@ -7,13 +7,13 @@ import (
 	"github.com/tmknom/actdocs/internal/util"
 )
 
-type ActionSpec struct {
-	Description *util.NullString    `json:"description"`
-	Inputs      []*ActionInputSpec  `json:"inputs"`
-	Outputs     []*ActionOutputSpec `json:"outputs"`
+type Spec struct {
+	Description *util.NullString `json:"description"`
+	Inputs      []*InputSpec     `json:"inputs"`
+	Outputs     []*OutputSpec    `json:"outputs"`
 }
 
-func (s *ActionSpec) toDescriptionMarkdown() string {
+func (s *Spec) toDescriptionMarkdown() string {
 	var sb strings.Builder
 	sb.WriteString(ActionDescriptionTitle)
 	sb.WriteString("\n\n")
@@ -21,7 +21,7 @@ func (s *ActionSpec) toDescriptionMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-func (s *ActionSpec) toInputsMarkdown() string {
+func (s *Spec) toInputsMarkdown() string {
 	var sb strings.Builder
 	sb.WriteString(ActionInputsTitle)
 	sb.WriteString("\n\n")
@@ -40,7 +40,7 @@ func (s *ActionSpec) toInputsMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-func (s *ActionSpec) toOutputsMarkdown() string {
+func (s *Spec) toOutputsMarkdown() string {
 	var sb strings.Builder
 	sb.WriteString(ActionOutputsTitle)
 	sb.WriteString("\n\n")
@@ -59,14 +59,14 @@ func (s *ActionSpec) toOutputsMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-type ActionInputSpec struct {
+type InputSpec struct {
 	Name        string           `json:"name"`
 	Default     *util.NullString `json:"default"`
 	Description *util.NullString `json:"description"`
 	Required    *util.NullString `json:"required"`
 }
 
-func (s *ActionInputSpec) toMarkdown() string {
+func (s *InputSpec) toMarkdown() string {
 	str := util.TableSeparator
 	str += fmt.Sprintf(" %s %s", s.Name, util.TableSeparator)
 	str += fmt.Sprintf(" %s %s", s.Description.StringOrEmpty(), util.TableSeparator)
@@ -75,12 +75,12 @@ func (s *ActionInputSpec) toMarkdown() string {
 	return str
 }
 
-type ActionOutputSpec struct {
+type OutputSpec struct {
 	Name        string           `json:"name"`
 	Description *util.NullString `json:"description"`
 }
 
-func (s *ActionOutputSpec) toMarkdown() string {
+func (s *OutputSpec) toMarkdown() string {
 	str := util.TableSeparator
 	str += fmt.Sprintf(" %s %s", s.Name, util.TableSeparator)
 	str += fmt.Sprintf(" %s %s", s.Description.StringOrEmpty(), util.TableSeparator)

--- a/internal/action/spec_test.go
+++ b/internal/action/spec_test.go
@@ -1,4 +1,4 @@
-package format
+package action
 
 import (
 	"testing"
@@ -26,7 +26,7 @@ func TestActionFormatter_toDescriptionMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &ActionSpec{Description: tc.description}
+		spec := &Spec{Description: tc.description}
 		got := spec.toDescriptionMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -38,31 +38,31 @@ func TestActionFormatter_toDescriptionMarkdown(t *testing.T) {
 func TestActionSpec_toInputsMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		inputs   []*ActionInputSpec
+		inputs   []*InputSpec
 		expected string
 	}{
 		{
 			name:     "empty",
-			inputs:   []*ActionInputSpec{},
+			inputs:   []*InputSpec{},
 			expected: "## Inputs\n\nN/A",
 		},
 		{
 			name: "minimal",
-			inputs: []*ActionInputSpec{
+			inputs: []*InputSpec{
 				{Name: "minimal", Default: NewNullValue(), Description: NewNullValue(), Required: NewNullValue()},
 			},
 			expected: "## Inputs\n\n| Name | Description | Default | Required |\n| :--- | :---------- | :------ | :------: |\n| minimal |  | n/a | no |",
 		},
 		{
 			name: "single",
-			inputs: []*ActionInputSpec{
+			inputs: []*InputSpec{
 				{Name: "single", Default: NewNotNullValue("5"), Description: NewNotNullValue("The number."), Required: NewNotNullValue("true")},
 			},
 			expected: "## Inputs\n\n| Name | Description | Default | Required |\n| :--- | :---------- | :------ | :------: |\n| single | The number. | `5` | yes |",
 		},
 		{
 			name: "multiple",
-			inputs: []*ActionInputSpec{
+			inputs: []*InputSpec{
 				{Name: "multiple-1", Default: NewNotNullValue("The string"), Description: NewNotNullValue("1"), Required: NewNotNullValue("false")},
 				{Name: "multiple-2", Default: NewNotNullValue("true"), Description: NewNotNullValue("2"), Required: NewNotNullValue("true")},
 			},
@@ -71,7 +71,7 @@ func TestActionSpec_toInputsMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &ActionSpec{Inputs: tc.inputs}
+		spec := &Spec{Inputs: tc.inputs}
 		got := spec.toInputsMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -83,31 +83,31 @@ func TestActionSpec_toInputsMarkdown(t *testing.T) {
 func TestActionSpec_toOutputsMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		outputs  []*ActionOutputSpec
+		outputs  []*OutputSpec
 		expected string
 	}{
 		{
 			name:     "empty",
-			outputs:  []*ActionOutputSpec{},
+			outputs:  []*OutputSpec{},
 			expected: "## Outputs\n\nN/A",
 		},
 		{
 			name: "minimal",
-			outputs: []*ActionOutputSpec{
+			outputs: []*OutputSpec{
 				{Name: "minimal", Description: NewNullValue()},
 			},
 			expected: "## Outputs\n\n| Name | Description |\n| :--- | :---------- |\n| minimal |  |",
 		},
 		{
 			name: "single",
-			outputs: []*ActionOutputSpec{
+			outputs: []*OutputSpec{
 				{Name: "single", Description: NewNotNullValue("The test description.")},
 			},
 			expected: "## Outputs\n\n| Name | Description |\n| :--- | :---------- |\n| single | The test description. |",
 		},
 		{
 			name: "multiple",
-			outputs: []*ActionOutputSpec{
+			outputs: []*OutputSpec{
 				{Name: "multiple-1", Description: NewNotNullValue("1")},
 				{Name: "multiple-2", Description: NewNotNullValue("2")},
 			},
@@ -116,7 +116,7 @@ func TestActionSpec_toOutputsMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &ActionSpec{Outputs: tc.outputs}
+		spec := &Spec{Outputs: tc.outputs}
 		got := spec.toOutputsMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -128,12 +128,12 @@ func TestActionSpec_toOutputsMarkdown(t *testing.T) {
 func TestActionInputSpec_toMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		sut      *ActionInputSpec
+		sut      *InputSpec
 		expected string
 	}{
 		{
 			name: "single line",
-			sut: &ActionInputSpec{
+			sut: &InputSpec{
 				Name:        "single-line",
 				Default:     NewNotNullValue("Default value"),
 				Description: NewNotNullValue("The test description."),
@@ -143,7 +143,7 @@ func TestActionInputSpec_toMarkdown(t *testing.T) {
 		},
 		{
 			name: "multi line",
-			sut: &ActionInputSpec{
+			sut: &InputSpec{
 				Name:        "multi-line",
 				Default:     NewNotNullValue("{\n  \"key\": \"value\"\n}"),
 				Description: NewNotNullValue("one\ntwo\nthree"),
@@ -165,12 +165,12 @@ func TestActionInputSpec_toMarkdown(t *testing.T) {
 func TestActionOutputSpec_toMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		sut      *ActionOutputSpec
+		sut      *OutputSpec
 		expected string
 	}{
 		{
 			name: "single line",
-			sut: &ActionOutputSpec{
+			sut: &OutputSpec{
 				Name:        "single-line",
 				Description: NewNotNullValue("The test description."),
 			},
@@ -178,7 +178,7 @@ func TestActionOutputSpec_toMarkdown(t *testing.T) {
 		},
 		{
 			name: "multi line",
-			sut: &ActionOutputSpec{
+			sut: &OutputSpec{
 				Name:        "multi-line",
 				Description: NewNotNullValue("one\ntwo\nthree"),
 			},

--- a/internal/cli/orchestration.go
+++ b/internal/cli/orchestration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/tmknom/actdocs/internal/action"
 	"github.com/tmknom/actdocs/internal/conf"
 	"github.com/tmknom/actdocs/internal/format"
 	"github.com/tmknom/actdocs/internal/parse"
@@ -33,7 +34,7 @@ func Orchestrate(source string, formatter *conf.FormatterConfig, sort *conf.Sort
 	formatted := ""
 	switch content.(type) {
 	case *parse.ActionAST:
-		formatter := format.NewActionFormatter(formatter)
+		formatter := action.NewActionFormatter(formatter)
 		formatted = formatter.Format(content.(*parse.ActionAST))
 	case *parse.WorkflowAST:
 		formatter := format.NewWorkflowFormatter(formatter)


### PR DESCRIPTION
- Renamed package from `format` to `action` for better separation of concerns
- Simplified struct names by removing redundant "Action" prefix
- Updated references in tests and orchestration logic
