### PR TITLE
refactor: move workflow formatting logic to internal/workflow package

### DIFF
--- a/internal/cli/orchestration.go
+++ b/internal/cli/orchestration.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/tmknom/actdocs/internal/action"
 	"github.com/tmknom/actdocs/internal/conf"
-	"github.com/tmknom/actdocs/internal/format"
 	"github.com/tmknom/actdocs/internal/parse"
 	"github.com/tmknom/actdocs/internal/read"
+	"github.com/tmknom/actdocs/internal/workflow"
 )
 
 func Orchestrate(source string, formatter *conf.FormatterConfig, sort *conf.SortConfig) (string, error) {
@@ -37,7 +37,7 @@ func Orchestrate(source string, formatter *conf.FormatterConfig, sort *conf.Sort
 		formatter := action.NewActionFormatter(formatter)
 		formatted = formatter.Format(content.(*parse.ActionAST))
 	case *parse.WorkflowAST:
-		formatter := format.NewWorkflowFormatter(formatter)
+		formatter := workflow.NewWorkflowFormatter(formatter)
 		formatted = formatter.Format(content.(*parse.WorkflowAST))
 	default:
 		return "", fmt.Errorf("unsupported AST type: %T", content)

--- a/internal/workflow/convert.go
+++ b/internal/workflow/convert.go
@@ -1,11 +1,11 @@
-package format
+package workflow
 
 import "github.com/tmknom/actdocs/internal/parse"
 
-func ConvertWorkflowSpec(ast *parse.WorkflowAST) *WorkflowSpec {
-	inputs := []*WorkflowInputSpec{}
+func ConvertWorkflowSpec(ast *parse.WorkflowAST) *Spec {
+	inputs := []*InputSpec{}
 	for _, inputAst := range ast.Inputs {
-		input := &WorkflowInputSpec{
+		input := &InputSpec{
 			Name:        inputAst.Name,
 			Default:     inputAst.Default,
 			Description: inputAst.Description,
@@ -15,9 +15,9 @@ func ConvertWorkflowSpec(ast *parse.WorkflowAST) *WorkflowSpec {
 		inputs = append(inputs, input)
 	}
 
-	secrets := []*WorkflowSecretSpec{}
+	secrets := []*SecretSpec{}
 	for _, secretAst := range ast.Secrets {
-		secret := &WorkflowSecretSpec{
+		secret := &SecretSpec{
 			Name:        secretAst.Name,
 			Description: secretAst.Description,
 			Required:    secretAst.Required,
@@ -25,23 +25,23 @@ func ConvertWorkflowSpec(ast *parse.WorkflowAST) *WorkflowSpec {
 		secrets = append(secrets, secret)
 	}
 
-	outputs := []*WorkflowOutputSpec{}
+	outputs := []*OutputSpec{}
 	for _, outputAst := range ast.Outputs {
-		output := &WorkflowOutputSpec{
+		output := &OutputSpec{
 			Name:        outputAst.Name,
 			Description: outputAst.Description,
 		}
 		outputs = append(outputs, output)
 	}
 
-	permissions := []*WorkflowPermissionSpec{}
+	permissions := []*PermissionSpec{}
 	for _, permissionAst := range ast.Permissions {
-		permission := &WorkflowPermissionSpec{
+		permission := &PermissionSpec{
 			Scope:  permissionAst.Scope,
 			Access: permissionAst.Access,
 		}
 		permissions = append(permissions, permission)
 	}
 
-	return &WorkflowSpec{Inputs: inputs, Secrets: secrets, Outputs: outputs, Permissions: permissions}
+	return &Spec{Inputs: inputs, Secrets: secrets, Outputs: outputs, Permissions: permissions}
 }

--- a/internal/workflow/formatter.go
+++ b/internal/workflow/formatter.go
@@ -1,4 +1,4 @@
-package format
+package workflow
 
 import (
 	"encoding/json"
@@ -8,26 +8,26 @@ import (
 	"github.com/tmknom/actdocs/internal/parse"
 )
 
-type WorkflowFormatter struct {
+type Formatter struct {
 	config *conf.FormatterConfig
-	*WorkflowSpec
+	*Spec
 }
 
-func NewWorkflowFormatter(config *conf.FormatterConfig) *WorkflowFormatter {
-	return &WorkflowFormatter{
+func NewWorkflowFormatter(config *conf.FormatterConfig) *Formatter {
+	return &Formatter{
 		config: config,
 	}
 }
 
-func (f *WorkflowFormatter) Format(ast *parse.WorkflowAST) string {
-	f.WorkflowSpec = ConvertWorkflowSpec(ast)
+func (f *Formatter) Format(ast *parse.WorkflowAST) string {
+	f.Spec = ConvertWorkflowSpec(ast)
 	if f.config.IsJson() {
-		return f.ToJson(f.WorkflowSpec)
+		return f.ToJson(f.Spec)
 	}
-	return f.ToMarkdown(f.WorkflowSpec, f.config)
+	return f.ToMarkdown(f.Spec, f.config)
 }
 
-func (f *WorkflowFormatter) ToJson(workflowSpec *WorkflowSpec) string {
+func (f *Formatter) ToJson(workflowSpec *Spec) string {
 	bytes, err := json.MarshalIndent(workflowSpec, "", "  ")
 	if err != nil {
 		return "{}"
@@ -35,7 +35,7 @@ func (f *WorkflowFormatter) ToJson(workflowSpec *WorkflowSpec) string {
 	return string(bytes)
 }
 
-func (f *WorkflowFormatter) ToMarkdown(workflowSpec *WorkflowSpec, config *conf.FormatterConfig) string {
+func (f *Formatter) ToMarkdown(workflowSpec *Spec, config *conf.FormatterConfig) string {
 	var sb strings.Builder
 	if len(workflowSpec.Inputs) != 0 || !config.Omit {
 		sb.WriteString(workflowSpec.toInputsMarkdown())

--- a/internal/workflow/formatter_test.go
+++ b/internal/workflow/formatter_test.go
@@ -1,4 +1,4 @@
-package format
+package workflow
 
 import (
 	"testing"
@@ -70,35 +70,35 @@ const basicWorkflowExpected = `## Inputs
 func TestWorkflowFormatter_ToJson(t *testing.T) {
 	cases := []struct {
 		name     string
-		json     *WorkflowSpec
+		json     *Spec
 		expected string
 	}{
 		{
 			name: "empty",
-			json: &WorkflowSpec{
-				Inputs:      []*WorkflowInputSpec{},
-				Secrets:     []*WorkflowSecretSpec{},
-				Outputs:     []*WorkflowOutputSpec{},
-				Permissions: []*WorkflowPermissionSpec{},
+			json: &Spec{
+				Inputs:      []*InputSpec{},
+				Secrets:     []*SecretSpec{},
+				Outputs:     []*OutputSpec{},
+				Permissions: []*PermissionSpec{},
 			},
 			expected: emptyWorkflowExpectedJson,
 		},
 		{
 			name: "full",
-			json: &WorkflowSpec{
-				Inputs: []*WorkflowInputSpec{
+			json: &Spec{
+				Inputs: []*InputSpec{
 					{Name: "minimal", Default: NewNullValue(), Description: NewNullValue(), Required: NewNullValue(), Type: NewNullValue()},
 					{Name: "full", Default: NewNotNullValue("true"), Description: NewNotNullValue("The input value."), Required: NewNotNullValue("true"), Type: NewNotNullValue("boolean")},
 				},
-				Secrets: []*WorkflowSecretSpec{
+				Secrets: []*SecretSpec{
 					{Name: "minimal", Description: NewNullValue(), Required: NewNullValue()},
 					{Name: "full", Description: NewNotNullValue("The secret value."), Required: NewNotNullValue("true")},
 				},
-				Outputs: []*WorkflowOutputSpec{
+				Outputs: []*OutputSpec{
 					{Name: "minimal", Description: NewNullValue()},
 					{Name: "full", Description: NewNotNullValue("The output value.")},
 				},
-				Permissions: []*WorkflowPermissionSpec{
+				Permissions: []*PermissionSpec{
 					{Scope: "contents", Access: "write"},
 					{Scope: "pull-requests", Access: "read"},
 				},
@@ -178,45 +178,45 @@ func TestWorkflowFormatter_ToMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
 		config   *conf.FormatterConfig
-		markdown *WorkflowSpec
+		markdown *Spec
 		expected string
 	}{
 		{
 			name:   "omit",
 			config: &conf.FormatterConfig{Format: conf.DefaultFormat, Omit: true},
-			markdown: &WorkflowSpec{
-				Inputs:      []*WorkflowInputSpec{},
-				Secrets:     []*WorkflowSecretSpec{},
-				Outputs:     []*WorkflowOutputSpec{},
-				Permissions: []*WorkflowPermissionSpec{},
+			markdown: &Spec{
+				Inputs:      []*InputSpec{},
+				Secrets:     []*SecretSpec{},
+				Outputs:     []*OutputSpec{},
+				Permissions: []*PermissionSpec{},
 			},
 			expected: "",
 		},
 		{
 			name:   "empty",
 			config: conf.DefaultFormatterConfig(),
-			markdown: &WorkflowSpec{
-				Inputs:      []*WorkflowInputSpec{},
-				Secrets:     []*WorkflowSecretSpec{},
-				Outputs:     []*WorkflowOutputSpec{},
-				Permissions: []*WorkflowPermissionSpec{},
+			markdown: &Spec{
+				Inputs:      []*InputSpec{},
+				Secrets:     []*SecretSpec{},
+				Outputs:     []*OutputSpec{},
+				Permissions: []*PermissionSpec{},
 			},
 			expected: emptyWorkflowExpected,
 		},
 		{
 			name:   "full",
 			config: conf.DefaultFormatterConfig(),
-			markdown: &WorkflowSpec{
-				Inputs: []*WorkflowInputSpec{
+			markdown: &Spec{
+				Inputs: []*InputSpec{
 					{Name: "single", Default: NewNotNullValue("5"), Description: NewNotNullValue("The number."), Required: NewNotNullValue("true"), Type: NewNotNullValue("number")},
 				},
-				Secrets: []*WorkflowSecretSpec{
+				Secrets: []*SecretSpec{
 					{Name: "single", Description: NewNotNullValue("The test description."), Required: NewNotNullValue("true")},
 				},
-				Outputs: []*WorkflowOutputSpec{
+				Outputs: []*OutputSpec{
 					{Name: "single", Description: NewNotNullValue("The test description.")},
 				},
-				Permissions: []*WorkflowPermissionSpec{
+				Permissions: []*PermissionSpec{
 					{Scope: "contents", Access: "write"},
 				},
 			},
@@ -226,7 +226,7 @@ func TestWorkflowFormatter_ToMarkdown(t *testing.T) {
 
 	for _, tc := range cases {
 		formatter := NewWorkflowFormatter(tc.config)
-		formatter.WorkflowSpec = tc.markdown
+		formatter.Spec = tc.markdown
 		got := formatter.ToMarkdown(tc.markdown, tc.config)
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
 			t.Errorf("diff: %s", diff)

--- a/internal/workflow/helpers_test.go
+++ b/internal/workflow/helpers_test.go
@@ -1,4 +1,4 @@
-package format
+package workflow
 
 import "github.com/tmknom/actdocs/internal/util"
 

--- a/internal/workflow/spec.go
+++ b/internal/workflow/spec.go
@@ -1,4 +1,4 @@
-package format
+package workflow
 
 import (
 	"fmt"
@@ -7,21 +7,21 @@ import (
 	"github.com/tmknom/actdocs/internal/util"
 )
 
-type WorkflowSpec struct {
-	Inputs      []*WorkflowInputSpec      `json:"inputs"`
-	Secrets     []*WorkflowSecretSpec     `json:"secrets"`
-	Outputs     []*WorkflowOutputSpec     `json:"outputs"`
-	Permissions []*WorkflowPermissionSpec `json:"permissions"`
+type Spec struct {
+	Inputs      []*InputSpec      `json:"inputs"`
+	Secrets     []*SecretSpec     `json:"secrets"`
+	Outputs     []*OutputSpec     `json:"outputs"`
+	Permissions []*PermissionSpec `json:"permissions"`
 }
 
-func (s *WorkflowSpec) toInputsMarkdown() string {
+func (s *Spec) toInputsMarkdown() string {
 	var sb strings.Builder
-	sb.WriteString(WorkflowInputsTitle)
+	sb.WriteString(InputsTitle)
 	sb.WriteString("\n\n")
 	if len(s.Inputs) != 0 {
-		sb.WriteString(WorkflowInputsColumnTitle)
+		sb.WriteString(InputsColumnTitle)
 		sb.WriteString("\n")
-		sb.WriteString(WorkflowInputsColumnSeparator)
+		sb.WriteString(InputsColumnSeparator)
 		sb.WriteString("\n")
 		for _, input := range s.Inputs {
 			sb.WriteString(input.toMarkdown())
@@ -33,14 +33,14 @@ func (s *WorkflowSpec) toInputsMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-func (s *WorkflowSpec) toSecretsMarkdown() string {
+func (s *Spec) toSecretsMarkdown() string {
 	var sb strings.Builder
-	sb.WriteString(WorkflowSecretsTitle)
+	sb.WriteString(SecretsTitle)
 	sb.WriteString("\n\n")
 	if len(s.Secrets) != 0 {
-		sb.WriteString(WorkflowSecretsColumnTitle)
+		sb.WriteString(SecretsColumnTitle)
 		sb.WriteString("\n")
-		sb.WriteString(WorkflowSecretsColumnSeparator)
+		sb.WriteString(SecretsColumnSeparator)
 		sb.WriteString("\n")
 		for _, secret := range s.Secrets {
 			sb.WriteString(secret.toMarkdown())
@@ -52,14 +52,14 @@ func (s *WorkflowSpec) toSecretsMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-func (s *WorkflowSpec) toOutputsMarkdown() string {
+func (s *Spec) toOutputsMarkdown() string {
 	var sb strings.Builder
-	sb.WriteString(WorkflowOutputsTitle)
+	sb.WriteString(OutputsTitle)
 	sb.WriteString("\n\n")
 	if len(s.Outputs) != 0 {
-		sb.WriteString(WorkflowOutputsColumnTitle)
+		sb.WriteString(OutputsColumnTitle)
 		sb.WriteString("\n")
-		sb.WriteString(WorkflowOutputsColumnSeparator)
+		sb.WriteString(OutputsColumnSeparator)
 		sb.WriteString("\n")
 		for _, output := range s.Outputs {
 			sb.WriteString(output.toMarkdown())
@@ -71,14 +71,14 @@ func (s *WorkflowSpec) toOutputsMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-func (s *WorkflowSpec) toPermissionsMarkdown() string {
+func (s *Spec) toPermissionsMarkdown() string {
 	var sb strings.Builder
-	sb.WriteString(WorkflowPermissionsTitle)
+	sb.WriteString(PermissionsTitle)
 	sb.WriteString("\n\n")
 	if len(s.Permissions) != 0 {
-		sb.WriteString(WorkflowPermissionsColumnTitle)
+		sb.WriteString(PermissionsColumnTitle)
 		sb.WriteString("\n")
-		sb.WriteString(WorkflowPermissionsColumnSeparator)
+		sb.WriteString(PermissionsColumnSeparator)
 		sb.WriteString("\n")
 		for _, permission := range s.Permissions {
 			sb.WriteString(permission.toMarkdown())
@@ -90,7 +90,7 @@ func (s *WorkflowSpec) toPermissionsMarkdown() string {
 	return strings.TrimSpace(sb.String())
 }
 
-type WorkflowInputSpec struct {
+type InputSpec struct {
 	Name        string           `json:"name"`
 	Default     *util.NullString `json:"default"`
 	Description *util.NullString `json:"description"`
@@ -98,7 +98,7 @@ type WorkflowInputSpec struct {
 	Type        *util.NullString `json:"type"`
 }
 
-func (s *WorkflowInputSpec) toMarkdown() string {
+func (s *InputSpec) toMarkdown() string {
 	str := util.TableSeparator
 	str += fmt.Sprintf(" %s %s", s.Name, util.TableSeparator)
 	str += fmt.Sprintf(" %s %s", s.Description.StringOrEmpty(), util.TableSeparator)
@@ -108,13 +108,13 @@ func (s *WorkflowInputSpec) toMarkdown() string {
 	return str
 }
 
-type WorkflowSecretSpec struct {
+type SecretSpec struct {
 	Name        string           `json:"name"`
 	Description *util.NullString `json:"description"`
 	Required    *util.NullString `json:"required"`
 }
 
-func (s *WorkflowSecretSpec) toMarkdown() string {
+func (s *SecretSpec) toMarkdown() string {
 	str := util.TableSeparator
 	str += fmt.Sprintf(" %s %s", s.Name, util.TableSeparator)
 	str += fmt.Sprintf(" %s %s", s.Description.StringOrEmpty(), util.TableSeparator)
@@ -122,24 +122,24 @@ func (s *WorkflowSecretSpec) toMarkdown() string {
 	return str
 }
 
-type WorkflowOutputSpec struct {
+type OutputSpec struct {
 	Name        string           `json:"name"`
 	Description *util.NullString `json:"description"`
 }
 
-func (s *WorkflowOutputSpec) toMarkdown() string {
+func (s *OutputSpec) toMarkdown() string {
 	str := util.TableSeparator
 	str += fmt.Sprintf(" %s %s", s.Name, util.TableSeparator)
 	str += fmt.Sprintf(" %s %s", s.Description.StringOrEmpty(), util.TableSeparator)
 	return str
 }
 
-type WorkflowPermissionSpec struct {
+type PermissionSpec struct {
 	Scope  string `json:"scope"`
 	Access string `json:"access"`
 }
 
-func (s *WorkflowPermissionSpec) toMarkdown() string {
+func (s *PermissionSpec) toMarkdown() string {
 	str := util.TableSeparator
 	str += fmt.Sprintf(" %s %s", s.Scope, util.TableSeparator)
 	str += fmt.Sprintf(" %s %s", s.Access, util.TableSeparator)
@@ -147,19 +147,19 @@ func (s *WorkflowPermissionSpec) toMarkdown() string {
 }
 
 const (
-	WorkflowInputsTitle           = "## Inputs"
-	WorkflowInputsColumnTitle     = "| Name | Description | Type | Default | Required |"
-	WorkflowInputsColumnSeparator = "| :--- | :---------- | :--- | :------ | :------: |"
+	InputsTitle           = "## Inputs"
+	InputsColumnTitle     = "| Name | Description | Type | Default | Required |"
+	InputsColumnSeparator = "| :--- | :---------- | :--- | :------ | :------: |"
 
-	WorkflowSecretsTitle           = "## Secrets"
-	WorkflowSecretsColumnTitle     = "| Name | Description | Required |"
-	WorkflowSecretsColumnSeparator = "| :--- | :---------- | :------: |"
+	SecretsTitle           = "## Secrets"
+	SecretsColumnTitle     = "| Name | Description | Required |"
+	SecretsColumnSeparator = "| :--- | :---------- | :------: |"
 
-	WorkflowOutputsTitle           = "## Outputs"
-	WorkflowOutputsColumnTitle     = "| Name | Description |"
-	WorkflowOutputsColumnSeparator = "| :--- | :---------- |"
+	OutputsTitle           = "## Outputs"
+	OutputsColumnTitle     = "| Name | Description |"
+	OutputsColumnSeparator = "| :--- | :---------- |"
 
-	WorkflowPermissionsTitle           = "## Permissions"
-	WorkflowPermissionsColumnTitle     = "| Scope | Access |"
-	WorkflowPermissionsColumnSeparator = "| :--- | :---- |"
+	PermissionsTitle           = "## Permissions"
+	PermissionsColumnTitle     = "| Scope | Access |"
+	PermissionsColumnSeparator = "| :--- | :---- |"
 )

--- a/internal/workflow/spec_test.go
+++ b/internal/workflow/spec_test.go
@@ -1,4 +1,4 @@
-package format
+package workflow
 
 import (
 	"testing"
@@ -9,31 +9,31 @@ import (
 func TestWorkflowSpec_toInputsMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		inputs   []*WorkflowInputSpec
+		inputs   []*InputSpec
 		expected string
 	}{
 		{
 			name:     "empty",
-			inputs:   []*WorkflowInputSpec{},
+			inputs:   []*InputSpec{},
 			expected: "## Inputs\n\nN/A",
 		},
 		{
 			name: "minimal",
-			inputs: []*WorkflowInputSpec{
+			inputs: []*InputSpec{
 				{Name: "minimal", Default: NewNullValue(), Description: NewNullValue(), Required: NewNullValue(), Type: NewNullValue()},
 			},
 			expected: "## Inputs\n\n| Name | Description | Type | Default | Required |\n| :--- | :---------- | :--- | :------ | :------: |\n| minimal |  | n/a | n/a | no |",
 		},
 		{
 			name: "single",
-			inputs: []*WorkflowInputSpec{
+			inputs: []*InputSpec{
 				{Name: "single", Default: NewNotNullValue("5"), Description: NewNotNullValue("The number."), Required: NewNotNullValue("true"), Type: NewNotNullValue("number")},
 			},
 			expected: "## Inputs\n\n| Name | Description | Type | Default | Required |\n| :--- | :---------- | :--- | :------ | :------: |\n| single | The number. | `number` | `5` | yes |",
 		},
 		{
 			name: "multiple",
-			inputs: []*WorkflowInputSpec{
+			inputs: []*InputSpec{
 				{Name: "multiple-1", Default: NewNotNullValue("The string"), Description: NewNotNullValue("1"), Required: NewNotNullValue("false"), Type: NewNotNullValue("string")},
 				{Name: "multiple-2", Default: NewNotNullValue("true"), Description: NewNotNullValue("2"), Required: NewNotNullValue("true"), Type: NewNotNullValue("boolean")},
 			},
@@ -42,7 +42,7 @@ func TestWorkflowSpec_toInputsMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &WorkflowSpec{Inputs: tc.inputs}
+		spec := &Spec{Inputs: tc.inputs}
 		got := spec.toInputsMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -54,31 +54,31 @@ func TestWorkflowSpec_toInputsMarkdown(t *testing.T) {
 func TestWorkflowSpec_toSecretsMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		secrets  []*WorkflowSecretSpec
+		secrets  []*SecretSpec
 		expected string
 	}{
 		{
 			name:     "empty",
-			secrets:  []*WorkflowSecretSpec{},
+			secrets:  []*SecretSpec{},
 			expected: "## Secrets\n\nN/A",
 		},
 		{
 			name: "minimal",
-			secrets: []*WorkflowSecretSpec{
+			secrets: []*SecretSpec{
 				{Name: "minimal", Description: NewNullValue(), Required: NewNullValue()},
 			},
 			expected: "## Secrets\n\n| Name | Description | Required |\n| :--- | :---------- | :------: |\n| minimal |  | no |",
 		},
 		{
 			name: "single",
-			secrets: []*WorkflowSecretSpec{
+			secrets: []*SecretSpec{
 				{Name: "single", Description: NewNotNullValue("The test description."), Required: NewNotNullValue("true")},
 			},
 			expected: "## Secrets\n\n| Name | Description | Required |\n| :--- | :---------- | :------: |\n| single | The test description. | yes |",
 		},
 		{
 			name: "multiple",
-			secrets: []*WorkflowSecretSpec{
+			secrets: []*SecretSpec{
 				{Name: "multiple-1", Description: NewNotNullValue("1"), Required: NewNotNullValue("false")},
 				{Name: "multiple-2", Description: NewNotNullValue("2"), Required: NewNotNullValue("true")},
 			},
@@ -87,7 +87,7 @@ func TestWorkflowSpec_toSecretsMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &WorkflowSpec{Secrets: tc.secrets}
+		spec := &Spec{Secrets: tc.secrets}
 		got := spec.toSecretsMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -99,31 +99,31 @@ func TestWorkflowSpec_toSecretsMarkdown(t *testing.T) {
 func TestWorkflowSpec_toOutputsMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		outputs  []*WorkflowOutputSpec
+		outputs  []*OutputSpec
 		expected string
 	}{
 		{
 			name:     "empty",
-			outputs:  []*WorkflowOutputSpec{},
+			outputs:  []*OutputSpec{},
 			expected: "## Outputs\n\nN/A",
 		},
 		{
 			name: "minimal",
-			outputs: []*WorkflowOutputSpec{
+			outputs: []*OutputSpec{
 				{Name: "minimal", Description: NewNullValue()},
 			},
 			expected: "## Outputs\n\n| Name | Description |\n| :--- | :---------- |\n| minimal |  |",
 		},
 		{
 			name: "single",
-			outputs: []*WorkflowOutputSpec{
+			outputs: []*OutputSpec{
 				{Name: "single", Description: NewNotNullValue("The test description.")},
 			},
 			expected: "## Outputs\n\n| Name | Description |\n| :--- | :---------- |\n| single | The test description. |",
 		},
 		{
 			name: "multiple",
-			outputs: []*WorkflowOutputSpec{
+			outputs: []*OutputSpec{
 				{Name: "multiple-1", Description: NewNotNullValue("1")},
 				{Name: "multiple-2", Description: NewNotNullValue("2")},
 			},
@@ -132,7 +132,7 @@ func TestWorkflowSpec_toOutputsMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &WorkflowSpec{Outputs: tc.outputs}
+		spec := &Spec{Outputs: tc.outputs}
 		got := spec.toOutputsMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -144,24 +144,24 @@ func TestWorkflowSpec_toOutputsMarkdown(t *testing.T) {
 func TestWorkflowSpec_toPermissionsMarkdown(t *testing.T) {
 	cases := []struct {
 		name        string
-		permissions []*WorkflowPermissionSpec
+		permissions []*PermissionSpec
 		expected    string
 	}{
 		{
 			name:        "empty",
-			permissions: []*WorkflowPermissionSpec{},
+			permissions: []*PermissionSpec{},
 			expected:    "## Permissions\n\nN/A",
 		},
 		{
 			name: "single",
-			permissions: []*WorkflowPermissionSpec{
+			permissions: []*PermissionSpec{
 				{Scope: "contents", Access: "write"},
 			},
 			expected: "## Permissions\n\n| Scope | Access |\n| :--- | :---- |\n| contents | write |",
 		},
 		{
 			name: "multiple",
-			permissions: []*WorkflowPermissionSpec{
+			permissions: []*PermissionSpec{
 				{Scope: "contents", Access: "write"},
 				{Scope: "pull-requests", Access: "read"},
 			},
@@ -170,7 +170,7 @@ func TestWorkflowSpec_toPermissionsMarkdown(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spec := &WorkflowSpec{Permissions: tc.permissions}
+		spec := &Spec{Permissions: tc.permissions}
 		got := spec.toPermissionsMarkdown()
 
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -182,12 +182,12 @@ func TestWorkflowSpec_toPermissionsMarkdown(t *testing.T) {
 func TestWorkflowInputSpec_toMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		sut      *WorkflowInputSpec
+		sut      *InputSpec
 		expected string
 	}{
 		{
 			name: "single line",
-			sut: &WorkflowInputSpec{
+			sut: &InputSpec{
 				Name:        "single-line",
 				Default:     NewNotNullValue("Default value"),
 				Description: NewNotNullValue("The test description."),
@@ -198,7 +198,7 @@ func TestWorkflowInputSpec_toMarkdown(t *testing.T) {
 		},
 		{
 			name: "multi line",
-			sut: &WorkflowInputSpec{
+			sut: &InputSpec{
 				Name:        "multi-line",
 				Default:     NewNotNullValue("{\n  \"key\": \"value\"\n}"),
 				Description: NewNotNullValue("one\ntwo\nthree"),
@@ -221,12 +221,12 @@ func TestWorkflowInputSpec_toMarkdown(t *testing.T) {
 func TestWorkflowSecretSpec_toMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		sut      *WorkflowSecretSpec
+		sut      *SecretSpec
 		expected string
 	}{
 		{
 			name: "single line",
-			sut: &WorkflowSecretSpec{
+			sut: &SecretSpec{
 				Name:        "single-line",
 				Description: NewNotNullValue("The test description."),
 				Required:    NewNotNullValue("false"),
@@ -235,7 +235,7 @@ func TestWorkflowSecretSpec_toMarkdown(t *testing.T) {
 		},
 		{
 			name: "multi line",
-			sut: &WorkflowSecretSpec{
+			sut: &SecretSpec{
 				Name:        "multi-line",
 				Description: NewNotNullValue("one\ntwo\nthree"),
 				Required:    NewNotNullValue("true"),
@@ -256,12 +256,12 @@ func TestWorkflowSecretSpec_toMarkdown(t *testing.T) {
 func TestWorkflowOutputSpec_toMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		sut      *WorkflowOutputSpec
+		sut      *OutputSpec
 		expected string
 	}{
 		{
 			name: "single line",
-			sut: &WorkflowOutputSpec{
+			sut: &OutputSpec{
 				Name:        "single-line",
 				Description: NewNotNullValue("The test description."),
 			},
@@ -269,7 +269,7 @@ func TestWorkflowOutputSpec_toMarkdown(t *testing.T) {
 		},
 		{
 			name: "multi line",
-			sut: &WorkflowOutputSpec{
+			sut: &OutputSpec{
 				Name:        "multi-line",
 				Description: NewNotNullValue("one\ntwo\nthree"),
 			},
@@ -289,12 +289,12 @@ func TestWorkflowOutputSpec_toMarkdown(t *testing.T) {
 func TestWorkflowPermissionSpec_toMarkdown(t *testing.T) {
 	cases := []struct {
 		name     string
-		sut      *WorkflowPermissionSpec
+		sut      *PermissionSpec
 		expected string
 	}{
 		{
 			name:     "valid",
-			sut:      &WorkflowPermissionSpec{Scope: "contents", Access: "write"},
+			sut:      &PermissionSpec{Scope: "contents", Access: "write"},
 			expected: "| contents | write |",
 		},
 	}


### PR DESCRIPTION
- Renamed package from `format` to `workflow` for better separation of concerns
- Simplified struct names by removing redundant "Workflow" prefix
- Updated references in tests and orchestration logic
