### PR TITLE
feat: support section-based markdown injection for GitHub Actions custom actions

### DIFF
--- a/internal/action/renderer.go
+++ b/internal/action/renderer.go
@@ -50,6 +50,13 @@ func (r *Renderer) checkBeginComment(spec *Spec, text string) {
 }
 
 func (r *Renderer) generateContent(spec *Spec, text string) string {
+	if text == beginDescriptionComment {
+		return spec.ToDescriptionMarkdown(r.Omit)
+	} else if text == beginInputsComment {
+		return spec.ToInputsMarkdown(r.Omit)
+	} else if text == beginOutputsComment {
+		return spec.ToOutputsMarkdown(r.Omit)
+	}
 	return spec.ToMarkdown(r.Omit)
 }
 

--- a/internal/action/renderer_test.go
+++ b/internal/action/renderer_test.go
@@ -11,10 +11,11 @@ func TestRenderer_scan(t *testing.T) {
 	cases := []struct {
 		name     string
 		spec     *Spec
+		template string
 		expected string
 	}{
 		{
-			name: "full parameter",
+			name: "all",
 			spec: &Spec{
 				Description: NewNotNullValue("This is a test Custom Action for actdocs."),
 				Inputs: []*InputSpec{
@@ -24,17 +25,32 @@ func TestRenderer_scan(t *testing.T) {
 					{"with-description", NewNotNullValue("The Render value with description.")},
 				},
 			},
+			template: testBaseDir + "testdata/output.md",
 			expected: fullRenderExpected,
+		},
+		{
+			name: "sections",
+			spec: &Spec{
+				Description: NewNotNullValue("This is a test Custom Action for actdocs."),
+				Inputs: []*InputSpec{
+					{"full-number", NewNotNullValue("5"), NewNotNullValue("The full number value."), NewNotNullValue("false")},
+				},
+				Outputs: []*OutputSpec{
+					{"with-description", NewNotNullValue("The Render value with description.")},
+				},
+			},
+			template: testBaseDir + "testdata/inject-sections.md",
+			expected: sectionsRenderExpected,
 		},
 	}
 
-	template, err := os.Open(testBaseDir + "testdata/output.md")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	defer func(file *os.File) { err = file.Close() }(template)
-
 	for _, tc := range cases {
+		template, err := os.Open(tc.template)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		defer func(file *os.File) { err = file.Close() }(template)
+
 		renderer := NewRenderer(template, false)
 		got := renderer.scan(tc.spec)
 		if diff := cmp.Diff(got, tc.expected); diff != "" {
@@ -70,6 +86,51 @@ This is a test Custom Action for actdocs.
 | with-description | The Render value with description. |
 
 <!-- actdocs end -->
+
+## Footer
+
+This is a footer.
+`
+
+const sectionsRenderExpected = `# Output test
+
+## Header
+
+This is a header.
+
+<!-- actdocs description start -->
+
+## Description
+
+This is a test Custom Action for actdocs.
+
+
+
+<!-- actdocs description end -->
+
+<!-- actdocs inputs start -->
+
+## Inputs
+
+| Name | Description | Default | Required |
+| :--- | :---------- | :------ | :------: |
+| full-number | The full number value. | ` + "`5`" + ` | no |
+
+
+
+<!-- actdocs inputs end -->
+
+<!-- actdocs outputs start -->
+
+## Outputs
+
+| Name | Description |
+| :--- | :---------- |
+| with-description | The Render value with description. |
+
+
+
+<!-- actdocs outputs end -->
 
 ## Footer
 

--- a/testdata/inject-sections.md
+++ b/testdata/inject-sections.md
@@ -1,0 +1,21 @@
+# Output test
+
+## Header
+
+This is a header.
+
+<!-- actdocs description start -->
+foo
+<!-- actdocs description end -->
+
+<!-- actdocs inputs start -->
+bar
+<!-- actdocs inputs end -->
+
+<!-- actdocs outputs start -->
+baz
+<!-- actdocs outputs end -->
+
+## Footer
+
+This is a footer.


### PR DESCRIPTION
- Allows injecting only description, inputs, or outputs into templates
- Improves control and modularity in custom action documentation
- Available via the `actdocs inject` command
