### PR TITLE
feat: support section-based markdown injection for GitHub Actions reusable workflows

### DIFF
--- a/internal/workflow/renderer.go
+++ b/internal/workflow/renderer.go
@@ -50,6 +50,15 @@ func (r *Renderer) checkBeginComment(spec *Spec, text string) {
 }
 
 func (r *Renderer) generateContent(spec *Spec, text string) string {
+	if text == beginInputsComment {
+		return spec.ToInputsMarkdown(r.Omit)
+	} else if text == beginSecretsComment {
+		return spec.ToSecretsMarkdown(r.Omit)
+	} else if text == beginOutputsComment {
+		return spec.ToOutputsMarkdown(r.Omit)
+	} else if text == beginPermissionsComment {
+		return spec.ToPermissionsMarkdown(r.Omit)
+	}
 	return spec.ToMarkdown(r.Omit)
 }
 

--- a/testdata/inject-workflow-sections.md
+++ b/testdata/inject-workflow-sections.md
@@ -1,0 +1,25 @@
+# Output test
+
+## Header
+
+This is a header.
+
+<!-- actdocs inputs start -->
+foo
+<!-- actdocs inputs end -->
+
+<!-- actdocs secrets start -->
+bar
+<!-- actdocs secrets end -->
+
+<!-- actdocs outputs start -->
+baz
+<!-- actdocs outputs end -->
+
+<!-- actdocs permissions start -->
+qux
+<!-- actdocs permissions end -->
+
+## Footer
+
+This is a footer.


### PR DESCRIPTION
- Allows injecting only inputs, secrets, outputs, or permissions into templates
- Improves control and modularity in reusable workflows documentation
- Available via the `actdocs inject` command
